### PR TITLE
Add ccmod.json

### DIFF
--- a/ccmod.json
+++ b/ccmod.json
@@ -1,0 +1,9 @@
+{
+    "id": "CrossCode C Edition",
+    "version": "1.0.0",
+    "title": "CrossCode C Edition",
+    "description": "The worst mod to ever be created.",
+    "repository": "https://github.com/elluminance/cc-c-edition",
+    "tags": ["cosmetic", "fun"],
+    "authors": "elluminance"
+}


### PR DESCRIPTION
A new `ccmod.json` standard now requires these fields I added.
Please create a new release or update the release `.ccmod` after merging.

